### PR TITLE
trait objects without an explicit `dyn` are deprecated

### DIFF
--- a/src/z80/io.rs
+++ b/src/z80/io.rs
@@ -26,7 +26,7 @@ impl Z80 {
     /// z80.install_input(0, Box::new(inp.clone()));
     ///```
     /// This will then be usable with `IN (0), <register>`.
-    pub fn install_input(&mut self, index: u8, device: Box<InputDevice>) {
+    pub fn install_input(&mut self, index: u8, device: Box<dyn InputDevice>) {
         self.input_devices.insert(index, device);
     }
 
@@ -39,7 +39,7 @@ impl Z80 {
     /// z80.install_output(0, Box::new(out.clone()));
     ///```
     /// This will then be usable with `OUT (0), <register>`.
-    pub fn install_output(&mut self, index: u8, device: Box<OutputDevice>) {
+    pub fn install_output(&mut self, index: u8, device: Box<dyn OutputDevice>) {
         self.output_devices.insert(index, device);
     }
 }

--- a/src/z80/mod.rs
+++ b/src/z80/mod.rs
@@ -22,8 +22,8 @@ pub struct Z80 {
 
     is_halted: bool,
 
-    input_devices: HashMap<u8, Box<io::InputDevice>>,
-    output_devices: HashMap<u8, Box<io::OutputDevice>>,
+    input_devices: HashMap<u8, Box<dyn io::InputDevice>>,
+    output_devices: HashMap<u8, Box<dyn io::OutputDevice>>,
 }
 
 impl Default for Z80 {


### PR DESCRIPTION
Signed-off-by: Maxime “pep” Buquet <pep@bouah.net>